### PR TITLE
feature: inherit plugin data resolver - allows inheritance of `pluginData` from `importer` when it has been stripped away.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oazmi/esbuild-plugin-deno",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "A portable non-invasive suite of esbuild plugins for loading http, jsr, npm, and import-maps. Supports Deno, Node, Bun, Web. Alternate to @luca/esbuild-deno-loader , while compatible with other plugins and native esbuild resolvers (e.g. css loader).",
 	"author": "Omar Azmi",
 	"license": "Lulz plz don't steal yet",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -3,7 +3,7 @@ import { ensureEndSlash, getUriScheme, pathToPosixPath, resolvePathFactory } fro
 
 
 export { dom_decodeURI, json_parse, json_stringify, object_assign, object_entries, object_fromEntries, object_keys, object_values, promise_outside, promise_resolve } from "@oazmi/kitchensink/alias"
-export { bind_array_push } from "@oazmi/kitchensink/binder"
+export { bind_array_push, bind_map_get, bind_map_has, bind_map_set } from "@oazmi/kitchensink/binder"
 export { InvertibleMap, invertMap } from "@oazmi/kitchensink/collections"
 export { execShellCommand, identifyCurrentRuntime, RUNTIME } from "@oazmi/kitchensink/crossenv"
 export { memorize } from "@oazmi/kitchensink/lambda"
@@ -21,7 +21,7 @@ export const enum DEBUG {
 	ASSERT = 1,
 	ERROR = 0,
 	PRODUCTION = 1,
-	MINIFY = 1,
+	MINIFY = 0,
 }
 
 // below is a custom path segment's absoluteness test function that will identify all `UriScheme` segments that are not "relative" as absolute paths,

--- a/src/plugins/filters/entry.ts
+++ b/src/plugins/filters/entry.ts
@@ -1,9 +1,50 @@
-/** this filter plugin intercepts all entities, injects plugin-data (if the entrity is an entry-point, or a dependency thereof),
- * and then makes them go through the {@link resolverPlugin} set of resolvers, in order to obtain the absolute path to the resource.
+/** this filter plugin intercepts all entities and makes them sequentially pass through three resolvers,
+ * so that an absolute path to the resource can be acquired in the best possible way (citation needed).
  * 
  * > [!important]
  * > you **must** include the {@link resolverPlugin} somewhere in your esbuild build-options,
- * > otherwise this plugin will not be able to resolve any path on its own.
+ * > otherwise this plugin will not be able to resolve to absolute paths on its own,
+ * > and all efforts of this plugin will pretty much be for naught.
+ * 
+ * ## details
+ * 
+ * an explanation of the operations performed by each of the three resolvers follows:
+ * 
+ * ### 1. initial plugin-data injector
+ * 
+ * this resolver simply inserts the user's {@link EntryPluginSetupConfig.initialPluginData} to **all** entry-points which lack an `args.pluginData`.
+ * but when {@link EntryPluginSetupConfig.forceInitialPluginData} is `true`, the entry-points with existing pluginData will be overwritten.
+ * 
+ * it is through this resolver that things like {@link CommonPluginData.importMap | import-maps}
+ * and the {@link CommonPluginData.runtimePackage | deno-package-resolver} get inserted into the entry-point resources,
+ * and then seeded into their dependencies.
+ * 
+ * ### 2. plugin-data inheritor
+ * 
+ * a fundamental problem (design choice?) with esbuild is that resource's `pluginData` **does not** propagate to the child-dependencies,
+ * when esbuild's native resolvers and loaders process the resource.
+ * this problem of stripping away valuable `pluginData` can also occur in external plugins that are not designed mindfully.
+ * 
+ * as a consequence, we would not be able to embed import-maps and runtime-package-resolvers that can be picked up by dependencies.
+ * 
+ * thus, to counteract this issue, this resolver inspects the `pluginData` of every resolved entity, stores it in a dictionary for book-keeping,
+ * and then, when a dependency-resource comes along with its plugin-data stripped away (i.e. `args.pluginData === undefined`),
+ * this resolver inserts its dependent's (`args.importer`) plugin-data.
+ * in effect, this resolver permits inheritance of plugin-data when it is stripped away.
+ * 
+ * ### 3. absolute-path resolution
+ * 
+ * finally, we come to the resolver which implicitly calls the namespaced resolvers of the {@link resolverPlugin},
+ * which is a pipeline that can resolve {@link CommonPluginData.importMap | import-maps},
+ * {@link CommonPluginData.runtimePackage | deno-packages},
+ * {@link nodeModulesResolverFactory | node-packages (`node_modules`)},
+ * and perform generic path-joining, in order to get the absolute path (doesn't have to be filesystem path) to the resource.
+ * 
+ * most resolvers of the {@link resolverPlugin} require {@link CommonPluginData | `pluginData`} to be useful.
+ * which is why we have to ensure its availability and inheritance through the two prior resolvers,
+ * in order for the {@link resolverPlugin} to be effective.
+ * 
+ * ---
  * 
  * > [!tip]
  * > while the placement order of the {@link resolverPlugin} does not matter (invariant behavior),
@@ -24,10 +65,10 @@
  * @module
 */
 
-import { isString, normalizePath, resolveAsUrl } from "../../deps.ts"
+import { DEBUG, isString, pathToPosixPath, resolveAsUrl } from "../../deps.ts"
 import { RuntimePackage } from "../../packageman/base.ts"
 import { DenoPackage } from "../../packageman/deno.ts"
-import type { resolverPlugin } from "../resolvers.ts"
+import type { nodeModulesResolverFactory, resolverPlugin } from "../resolvers.ts"
 import type { CommonPluginData, EsbuildPlugin, EsbuildPluginBuild, EsbuildPluginSetup, OnResolveArgs, OnResolveCallback } from "../typedefs.ts"
 import { defaultEsbuildNamespaces, PLUGIN_NAMESPACE } from "../typedefs.ts"
 
@@ -64,20 +105,25 @@ export interface EntryPluginSetupConfig {
 	*/
 	forceInitialPluginData: boolean | "merge" | "overwrite"
 
-	/** specify if you wish for the dependencies of the captured `"entry-points"` to be captured as well?
+	/** specify if `pluginData` should be passed down from an resource to its dependency-resources,
+	 * if they have been stripped off of their plugin data (i.e. `dependency_args.pluginData === undefined`).
 	 * 
-	 * _why_? you ask? that's because esbuild's native loaders do not propagate the `pluginData` passed by the resolver, onto the dependency entities.
-	 * this means that the initial-data will be lost when a dependency of an entry-point is being resolved, due to esbuild's native loader not preserving it.
-	 * thus, our plugin will have to keep track of which entities it has already pushed its initial-data onto,
-	 * and then be on the lookout for dependency entities that come from an importer file that has had the initial-data injected into it,
-	 * so that this dependency entity can also be injected with the same initial-data.
+	 * > [!note]
+	 * > you might be questioning _why would the dependency-resource lose the plugin data that its importer had?_
+	 * > 
+	 * > the reason is that esbuild's native resolvers and loaders strip away plugin data when any resource goes through them.
+	 * > (i.e. esbuild does not propagate the plugin data on its own if it resolves or loads something)
+	 * > moreover, poorly written plugins may do the same.
+	 * > which is why this option helps you retrieve lost plugin data from the parent dependent resource (the `args.importer`).
 	 * 
-	 * if you don't want the initial-data to be injected onto the entry-point's dependencies (and deep grandchildren dependencies),
-	 * make sure to turn off this option, otherwise it'll be enabled by default.
+	 * > [!important]
+	 * > generally, you would always want this to be left as `true`.
+	 * > otherwise, npm-packages and local-files, that are implicitly resolved by esbuild in this library,
+	 * > will lose their access to the {@link CommonPluginData.importMap | import-maps} and {@link CommonPluginData.runtimePackage | deno-package-resolver}.
 	 * 
 	 * @defaultValue `true`
 	*/
-	captureDependencies: boolean
+	enableInheritPluginData: boolean
 
 	/** specify which `namespace`s should be intercepted by the entry-point plugin.
 	 * all other `namespace`s will not be processed by this plugin.
@@ -95,21 +141,26 @@ const defaultEntryPluginSetup: EntryPluginSetupConfig = {
 	filters: [/.*/],
 	initialPluginData: undefined,
 	forceInitialPluginData: false,
-	captureDependencies: true,
+	enableInheritPluginData: true,
 	acceptNamespaces: defaultEsbuildNamespaces,
 }
 
-/** this filter plugin intercepts all entities, injects plugin-data (if the entrity is an entry-point, or a dependency thereof),
+/** this filter plugin intercepts all entities, injects and propagates plugin-data (if the entity is an entry-point, or a dependency with no plugin-data),
  * and then makes them go through the {@link resolverPlugin} set of resolvers, in order to obtain the absolute path to the resource.
  * 
- * for more details see the submodule comments: {@link "plugins/filters/entry"}.
+ * for an explanation, see detailed comments of this submodule: {@link "plugins/filters/entry"}.
 */
 export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): EsbuildPluginSetup => {
 	const
-		{ filters, initialPluginData: _initialPluginData, forceInitialPluginData, acceptNamespaces: _acceptNamespaces } = { ...defaultEntryPluginSetup, ...config },
+		{ filters, initialPluginData: _initialPluginData, forceInitialPluginData, enableInheritPluginData, acceptNamespaces: _acceptNamespaces } = { ...defaultEntryPluginSetup, ...config },
 		acceptNamespaces = new Set([..._acceptNamespaces, PLUGIN_NAMESPACE.LOADER_HTTP]),
-		ALREADY_CAPTURED_BY_INITIAL: unique symbol = Symbol(),
-		ALREADY_CAPTURED_BY_RESOLVER: unique symbol = Symbol()
+		// contains a record of **all** resources that have passed through the `inheritPluginDataInjector`,
+		// so that dependency resources which have been stripped out of their `pluginData` can inherit it back from their `importer`'s saved `pluginData`.
+		// the keys are resolved paths (posix enforced), and the values are the plugin-data of the resolved resource.
+		importerPluginDataRecord = new Map<string, CommonPluginData>(),
+		ALREADY_CAPTURED_BY_INITIAL: unique symbol = Symbol(DEBUG.MINIFY ? "" : "[oazmi-entry]: already captured by initial-data-injector"),
+		ALREADY_CAPTURED_BY_INHERITOR: unique symbol = Symbol(DEBUG.MINIFY ? "" : "[oazmi-entry]: already captured by inherit-data-injector"),
+		ALREADY_CAPTURED_BY_RESOLVER: unique symbol = Symbol(DEBUG.MINIFY ? "" : "[oazmi-entry]: already captured by absolute-path-resolver")
 
 	return async (build: EsbuildPluginBuild) => {
 		const
@@ -124,7 +175,7 @@ export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): Esbu
 			initialPluginData.runtimePackage = await resolveRuntimePackage(build, initialRuntimePackage)
 		})
 
-		/** this resolver simply inserts the user's {@link initialPluginData} to **all** entry-points which lack a `args.pluginData`.
+		/** this resolver simply inserts the user's {@link initialPluginData} to **all** entry-points which lack an `args.pluginData`.
 		 * but when {@link forceInitialPluginData} is `true`, the entry-points with existing pluginData will be overwritten.
 		*/
 		const initialPluginDataInjector: OnResolveCallback = async (args: OnResolveArgs) => {
@@ -132,8 +183,6 @@ export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): Esbu
 				{ path, pluginData, ...rest_args } = args,
 				{ kind, namespace } = rest_args
 
-			// if no `initialPluginData` exists, then return immediately.
-			if (!initialPluginDataExists) { return }
 			// if the entity is not an entry-point, then skip it.
 			if (kind !== "entry-point") { return }
 			// if the plugin marker already exists for this entity, then we've already processed it once,
@@ -146,16 +195,16 @@ export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): Esbu
 			// if there is an existing non-empty plugin data and `forceInitialPluginData` is not enabled (default), then skip this entity
 			if (pluginData !== undefined && !forceInitialPluginData) { return }
 
-			const merged_plugin_data = forceInitialPluginData === "merge"
+			const merged_pluginData = forceInitialPluginData === "merge"
 				? { ...initialPluginData, ...pluginData, [ALREADY_CAPTURED_BY_INITIAL]: true }
 				: { ...initialPluginData, [ALREADY_CAPTURED_BY_INITIAL]: true }
 
-			// below, we implicitly (hope to) call the `absolutePathResolver`, so long as no other "capture-all" plugin exists before this plugin.
-			const resolved_result = await build.resolve(path, { ...rest_args, pluginData: merged_plugin_data })
-			// if esbuild's native resolver had resolved the `path`, then the `merged_plugin_data` that we just inserted WILL be lost.
+			// below, we implicitly (hope to) call the `inheritPluginDataInjector`, so long as no other "capture-all" plugin exists before this plugin.
+			const resolved_result = await build.resolve(path, { ...rest_args, pluginData: merged_pluginData })
+			// if esbuild's native resolver had resolved the `path`, then the `merged_pluginData` that we just inserted WILL be lost.
 			// i.e. `resolved_result.pluginData === undefined` if esbuild's native resolver took care of the path-resolution.
-			// in such cases, we would like to re-insert our `merged_plugin_data` again, before returning the result
-			if (resolved_result.pluginData === undefined) { resolved_result.pluginData = merged_plugin_data }
+			// in such cases, we would like to re-insert our `merged_pluginData` again, before returning the result
+			resolved_result.pluginData ??= merged_pluginData
 
 			// NOTICE: we intentionally do not remove the `ALREADY_CAPTURED_BY_INITIAL` marker from the result's plugin-data.
 			//   even though it is practically impossible for this resource to somehow end up back inside this resolver,
@@ -163,6 +212,61 @@ export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): Esbu
 			return resolved_result
 		}
 
+		/** this resolver ensures that the incoming resources have some non-undefined `pluginData`,
+		 * otherwise it will insert the `pluginData` of its parent `importer` resource.
+		 * (i.e. dependency resources will inherit their parent importer's `pluginData` if they are lacking one)
+		 * 
+		 * moreover, internally, a call to `build.resolver()` is made to resolve the path of the current resource.
+		 * however, if the resolved result is lacking a `pluginData`
+		 * (possibly due to being resolved by esbuild's native resolver, which strips away `pluginData`),
+		 * then the `pluginData` _prior_ to the path-resolution will be re-inserted into the result.
+		*/
+		const inheritPluginDataInjector: OnResolveCallback = async (args: OnResolveArgs) => {
+			const
+				{ path, pluginData, ...rest_args } = args,
+				{ importer, namespace } = rest_args
+			if ((pluginData ?? {})[ALREADY_CAPTURED_BY_INHERITOR]) { return }
+			if (!acceptNamespaces.has(namespace)) { return }
+
+			// if `pluginData` is missing, then inherit it from the parent `importer`, and retry (via recursion).
+			if (pluginData === undefined) {
+				const parentPluginData = importerPluginDataRecord.get(pathToPosixPath(importer))
+				return parentPluginData
+					? inheritPluginDataInjector({ ...rest_args, path, pluginData: parentPluginData })
+					: undefined
+			}
+
+			const
+				prior_pluginData: CommonPluginData = { ...pluginData, [ALREADY_CAPTURED_BY_INHERITOR]: true },
+				// below, we implicitly (hope to) call the `absolutePathResolver`, so long as no other "capture-all" plugin exists before this plugin.
+				resolved_result = await build.resolve(path, { ...rest_args, pluginData: prior_pluginData }),
+				resolved_pluginData = {
+					// if esbuild's native resolver had resolved the `path`, then the `prior_pluginData` WILL be lost, and we will need to re-insert it.
+					...(resolved_result.pluginData ?? prior_pluginData),
+
+					// we must also disable the `ALREADY_CAPTURED_BY_INHERITOR` marker, since the `resolved_result` is ready to go to the loader,
+					// however, we don't want the dependencies (which will inherit the `pluginData`) to have their capture marker set to `true`,
+					// since they haven't actually been captured by this resolver yet.
+					[ALREADY_CAPTURED_BY_INHERITOR]: false,
+				}
+
+			// finally, we save the resolved plugin data to the global record, so that its dependencies can inherit it when needed.
+			// TODO: consider the scenario where the same `path` is processed,
+			//   leading up to the same `resolved_result.path` that already exists in `importerPluginDataRecord`.
+			//   should we still update the record with a potentially new and different `resolved_pluginData`?, or should we abstain from that?
+			importerPluginDataRecord.set(pathToPosixPath(resolved_result.path), resolved_pluginData)
+			resolved_result.pluginData = resolved_pluginData
+			return resolved_result
+		}
+
+		/** by this point, our resource will have acquired any `pluginData` that was intended for it.
+		 * so all that is left to be done is to obtain the absolute-path to the resource,
+		 * by implicitly resolving it though the {@link resolverPlugin}'s namespace.
+		 * 
+		 * once we obtain the resolved absolute-path, we run it though `build.resolve` again (but in the resource's original namespace this time),
+		 * so that whichever plugin that this resource was intended for (including esbuild's native resolver)
+		 * will receive it gracefully, and resolve it in their own accord.
+		*/
 		const absolutePathResolver: OnResolveCallback = async (args: OnResolveArgs) => {
 			if ((args.pluginData ?? {})[ALREADY_CAPTURED_BY_RESOLVER]) { return }
 			if (!acceptNamespaces.has(args.namespace)) { return }
@@ -173,19 +277,22 @@ export const entryPluginSetup = (config?: Partial<EntryPluginSetupConfig>): Esbu
 				{ path: abs_path, pluginData: abs_pluginData = {}, namespace: _0 } = abs_result,
 				next_pluginData = { ...abs_pluginData, [ALREADY_CAPTURED_BY_RESOLVER]: true },
 				resolved_result = await build.resolve(abs_path, { ...rest_args, namespace: original_ns, pluginData: next_pluginData })
-			// if esbuild's native resolver had resolved the `path`, then the `merged_plugin_data` that we just inserted WILL be lost.
-			// i.e. `resolved_result.pluginData === undefined` if esbuild's native resolver took care of the path-resolution.
-			// in such cases, we would like to re-insert our `merged_plugin_data` again, before returning the result
-			if (resolved_result.pluginData === undefined) { resolved_result.pluginData = next_pluginData }
-			// we must also disable the `ALREADY_CAPTURED_BY_RESOLVER` marker, since the `resolved_result` is ready to go to the loader,
-			// however, we don't want the dependencies (which will inherit the `pluginData`) to have their capture marker set to `true`,
-			// since they haven't actually been captured by this resolver yet.
-			resolved_result.pluginData = { ...resolved_result.pluginData, [ALREADY_CAPTURED_BY_RESOLVER]: false }
+
+			resolved_result.pluginData = {
+				// if esbuild's native resolver had resolved the `path`, then the `next_pluginData` WILL be lost, and we will need to re-insert it.
+				...(resolved_result.pluginData ?? next_pluginData),
+
+				// we must also disable the `ALREADY_CAPTURED_BY_RESOLVER` marker, since the `resolved_result` is ready to go to the loader,
+				// however, we don't want the dependencies (which will inherit the `pluginData`) to have their capture marker set to `true`,
+				// since they haven't actually been captured by this resolver yet.
+				[ALREADY_CAPTURED_BY_RESOLVER]: false,
+			}
 			return resolved_result
 		}
 
 		for (const filter of filters) {
-			build.onResolve({ filter }, initialPluginDataInjector)
+			if (initialPluginDataExists) { build.onResolve({ filter }, initialPluginDataInjector) }
+			if (enableInheritPluginData) { build.onResolve({ filter }, inheritPluginDataInjector) }
 			build.onResolve({ filter }, absolutePathResolver)
 		}
 	}

--- a/src/plugins/filters/jsr.ts
+++ b/src/plugins/filters/jsr.ts
@@ -85,9 +85,10 @@ export const jsrPluginSetup = (config: Partial<JsrPluginSetupConfig> = {}): Esbu
 				pluginData: {
 					...restPluginData,
 					runtimePackage,
-					// since we don't want the the entry-plugin's initial plugin-data injection to intervene any more,
-					// we'll set the `useInitialPluginData` plugin-data option to `false`.
-					resolverConfig: { ...resolverConfig, useInitialPluginData: false },
+					// we don't want node-resolution occurring inside of the jsr-package.
+					// however, any dependency in the jsr-package that uses the "npm:" specifier will be resolved correctly via the npm-plugin,
+					// and inside of that npm-package, the node-resolution will be re-enabled.
+					resolverConfig: { ...resolverConfig, useNodeModules: false },
 				} satisfies CommonPluginData,
 			})
 		}

--- a/src/plugins/filters/npm.ts
+++ b/src/plugins/filters/npm.ts
@@ -283,7 +283,7 @@ export const npmPluginSetup = (config: DeepPartial<NpmPluginSetupConfig> = {}): 
 				...rest_args,
 				resolveDir: valid_resolve_dir,
 				namespace: PLUGIN_NAMESPACE.RESOLVER_PIPELINE,
-				pluginData: { ...restPluginData, resolverConfig: { useNodeModules: true } } satisfies CommonPluginData,
+				pluginData: { ...restPluginData, resolverConfig: { useRuntimePackage: false, useImportMap: false, useNodeModules: true } } satisfies CommonPluginData,
 			})
 			const resolved_path = abs_result.path
 			if (DEBUG.LOG && logFn) {

--- a/src/plugins/mod.ts
+++ b/src/plugins/mod.ts
@@ -16,7 +16,7 @@ export { DIRECTORY } from "./typedefs.ts"
 
 /** the configuration interface for the deno esbuild plugins suite {@link denoPlugins}. */
 export interface DenoPluginsConfig extends
-	Pick<EntryPluginSetupConfig, "pluginData">,
+	Pick<EntryPluginSetupConfig, "initialPluginData">,
 	Pick<ResolverPluginSetupConfig, "log">,
 	Pick<NpmPluginSetupConfig, "autoInstall" | "nodeModulesDirs">,
 	Pick<ImportMapResolverConfig, "globalImportMap"> {
@@ -54,7 +54,7 @@ export interface DenoPluginsConfig extends
 }
 
 const defaultDenoPluginsConfig: DenoPluginsConfig = {
-	pluginData: {},
+	initialPluginData: undefined,
 	log: false,
 	logFor: ["npm", "resolver"],
 	autoInstall: true,
@@ -83,11 +83,11 @@ export const denoPlugins = (config?: Partial<DenoPluginsConfig>): [
 	resolver_pipeline_plugin: EsbuildPlugin,
 ] => {
 	const
-		{ acceptNamespaces, autoInstall, getCwd, globalImportMap, log, logFor, nodeModulesDirs, pluginData } = { ...defaultDenoPluginsConfig, ...config },
+		{ acceptNamespaces, autoInstall, getCwd, globalImportMap, log, logFor, nodeModulesDirs, initialPluginData } = { ...defaultDenoPluginsConfig, ...config },
 		resolvePath = resolvePathFactory(getCwd, isAbsolutePath)
 
 	return [
-		entryPlugin({ pluginData, acceptNamespaces }),
+		entryPlugin({ initialPluginData, acceptNamespaces }),
 		httpPlugin({ acceptNamespaces, log: logFor.includes("http") ? log : false }),
 		jsrPlugin({ acceptNamespaces }),
 		npmPlugin({ acceptNamespaces, autoInstall, log: logFor.includes("npm") ? log : false, nodeModulesDirs }),

--- a/src/plugins/typedefs.ts
+++ b/src/plugins/typedefs.ts
@@ -56,14 +56,24 @@ export interface CommonPluginData {
 
 	/** you may control which resolvers to disable through the use of this property. */
 	resolverConfig?: {
-		/** enable or disable the initial `pluginData` injection (performed by the {@link entryPlugin}) for the current entity.
-		 * setting this to `false` is needed when switching the scope to a new package,
-		 * so that your current initial runtime-package and import-maps do not interfere/overwite the intended plugin data.
-		 * (for instance, this will be needed when moving to a self-contained remote jsr-package scope, away from your filesystem).
+		/** enable or disable missing `pluginData` inheritance (performed by the {@link entryPlugin}) for the current entity.
+		 * 
+		 * setting this to `false` will make the inheritance injector **not** record this entity's `pluginData`.
+		 * thus, in effect, all of the current entity's dependencies will not be able to inherit this entity's `pluginData`,
+		 * even when they (the dependencies) are lacking one (i.e. `dependency_args.pluginData === undefined`).
+		 * 
+		 * this _could_ be useful when switching the scope to a new, isolated, package.
+		 * but you could also strip away the plugin data in the current entity so that its dependencies don't pick up anything.
+		 * so, the only scenario where this could be useful is when:
+		 * - you've got a custom loader, which requires some `pluginData` specific to the current entity.
+		 * - but your loader also returns `puginData: undefined`, making its dependencies acquire `dependency_args.puginData === undefined`.
+		 * - however, you **don't** want `dependency_args.puginData` to now inherit from `args.pluginData` (the importer's plugin data).
+		 * - thus, to solve this issue, you make sure that the importer's `args.pluginData` is never recorded by the inheritance resolver.
+		 *   so, you achieve that by setting `args.pluginData.resolverConfig.useInheritPluginData` to `false`.
 		 * 
 		 * @defaultValue `true` (enabled)
 		*/
-		useInitialPluginData?: boolean
+		useInheritPluginData?: boolean
 
 		/** enable or disable import-map resolution for the current entity.
 		 * 

--- a/test/1/mod.test.ts
+++ b/test/1/mod.test.ts
@@ -44,7 +44,7 @@ Deno.test("test http plugin", async () => {
 		plugins: [
 			npmPlugin({ autoInstall: true, log: true, }),
 			entryPlugin({
-				pluginData: {
+				initialPluginData: {
 					runtimePackage: "./deno.json",
 					importMap: { "https://2d-lib": "https://jsr.io/@oazmi/kitchensink/0.9.2/src/array2d.ts" },
 					resolverConfig: { useNodeModules: false },


### PR DESCRIPTION
this pull request adds a new _"inherit-plugin-data"_ resolver to the `entryPlugin`, in `/src/plugins/filters/entry.ts`.

with this resolver, entities which have had their `pluginData` stripped away from them (either due to esbuild's native resolver/loader or some other external plugin) can inherit their parent `importer`'s `pluginData`.

effectively, this allows us to propagate `pluginData` across dependency-entities, without worrying that some prick of a plugin would discard it, because we'll insert it back.
this guarantee also makes it much easier to reason about the other filter-plugins' code.

### details:
- in the entry-plugin inside `/src/plugins/filters/entry.ts`:
  - purged the old `entryPluginDataInjector` resolver and replaced it with `initialPluginDataInjector`, which only inserts initial plugin-data to entry-points.
  - add the new `inheritPluginDataInjector` resolver for inheritance of `pluginData` from the `importer` if its own plugin-data has been lost.
    - the `inheritPluginDataInjector` records the `pluginData` of every resolved entity's path inside a large `Map<resolvedPath, pluginData>`.
    - if an entity comes along, lacking a `pluginData`, we look for its parent-importer's plugin-data inside of the `Map<resolvedPath, pluginData>`, and inject it into the entity, before sending it off for resolution (via `build.resolve`).
  - add a large module comment explaining the entry-plugin's task (inject, inherit, i(e)valuate)

### breaking changes?
- yesn't. at the top level (`denoPlugins`), only the configuration `DenoPluginsConfig.pluginData` has been renamed (reverted back?) to `DenoPluginsConfig.initialPluginData`.
- and a few more options have been added that are not really worthy of explaining.
