### PR TITLE
feature: introduce workspace package support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oazmi/esbuild-plugin-deno",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "A portable non-invasive suite of esbuild plugins for loading http, jsr, npm, and import-maps. Supports Deno, Node, Bun, Web. Alternate to @luca/esbuild-deno-loader , while compatible with other plugins and native esbuild resolvers (e.g. css loader).",
 	"author": "Omar Azmi",
 	"license": "Lulz plz don't steal yet",
@@ -140,7 +140,7 @@
 			"description": "run typescript validity test on source code, and evaluate the unit tests in the `./test/` directory."
 		},
 		"test-doc": {
-			"command": "deno test -A --doc \"./src/*\"",
+			"command": "deno test -A --doc \"./src/**\"",
 			"description": "evaluate the documentation comment tests and examples inside of the source code."
 		},
 		"publish-jsr": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oazmi/esbuild-plugin-deno",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"description": "A portable non-invasive suite of esbuild plugins for loading http, jsr, npm, and import-maps. Supports Deno, Node, Bun, Web. Alternate to @luca/esbuild-deno-loader , while compatible with other plugins and native esbuild resolvers (e.g. css loader).",
 	"author": "Omar Azmi",
 	"license": "Lulz plz don't steal yet",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -4,7 +4,7 @@ import { isString } from "@oazmi/kitchensink/struct"
 import type { RelativePathResolverConfig } from "./plugins/resolvers.ts"
 
 
-export { array_isEmpty, dom_decodeURI, json_parse, json_stringify, number_isFinite, number_parseInt, object_assign, object_entries, object_fromEntries, object_keys, object_values, promise_outside, promise_resolve } from "@oazmi/kitchensink/alias"
+export { array_isEmpty, dom_decodeURI, json_parse, json_stringify, number_isFinite, number_parseInt, object_assign, object_entries, object_fromEntries, object_keys, object_values, promise_all, promise_outside, promise_resolve } from "@oazmi/kitchensink/alias"
 export { bind_array_push, bind_map_get, bind_map_has, bind_map_set } from "@oazmi/kitchensink/binder"
 export { InvertibleMap, invertMap } from "@oazmi/kitchensink/collections"
 export { execShellCommand, identifyCurrentRuntime, RUNTIME } from "@oazmi/kitchensink/crossenv"
@@ -12,7 +12,7 @@ export { memorize } from "@oazmi/kitchensink/lambda"
 export { ensureEndSlash, ensureFileUrlIsLocalPath, ensureStartDotSlash, fileUrlToLocalPath, getUriScheme, joinPaths, normalizePath, parseFilepathInfo, parsePackageUrl, pathToPosixPath, resolveAsUrl, resolvePathFactory } from "@oazmi/kitchensink/pathman"
 export { maxSatisfying as semverMaxSatisfying, minSatisfying as semverMinSatisfying } from "@oazmi/kitchensink/semver"
 export { escapeLiteralStringForRegex, jsoncRemoveComments, replacePrefix, replaceSuffix } from "@oazmi/kitchensink/stringman"
-export { isArray, isObject, isString } from "@oazmi/kitchensink/struct"
+export { constructorOf, isArray, isObject, isString } from "@oazmi/kitchensink/struct"
 export type { ConstructorOf, DeepPartial, MaybePromise, Optional } from "@oazmi/kitchensink/typedefs"
 export type * as esbuild from "npm:esbuild@^0.25.0"
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -4,7 +4,7 @@ import { isString } from "@oazmi/kitchensink/struct"
 import type { RelativePathResolverConfig } from "./plugins/resolvers.ts"
 
 
-export { array_isEmpty, dom_decodeURI, json_parse, json_stringify, number_isFinite, number_parseInt, object_assign, object_entries, object_fromEntries, object_keys, object_values, promise_all, promise_outside, promise_resolve } from "@oazmi/kitchensink/alias"
+export { array_isArray, array_isEmpty, dom_decodeURI, json_parse, json_stringify, number_isFinite, number_parseInt, object_assign, object_entries, object_fromEntries, object_keys, object_values, promise_all, promise_outside, promise_resolve } from "@oazmi/kitchensink/alias"
 export { bind_array_push, bind_map_get, bind_map_has, bind_map_set } from "@oazmi/kitchensink/binder"
 export { InvertibleMap, invertMap } from "@oazmi/kitchensink/collections"
 export { execShellCommand, identifyCurrentRuntime, RUNTIME } from "@oazmi/kitchensink/crossenv"
@@ -29,6 +29,11 @@ export const enum DEBUG {
 export const isAbsolutePath = (segment: string): boolean => {
 	const scheme = getUriScheme(segment) ?? "relative"
 	return scheme !== "relative"
+}
+
+// this function helps with testing if a given path segment is guaranteed to be a relative path segment (i.e. begins with "./" or "../").
+export const isCertainlyRelativePath = (segment: string): boolean => {
+	return segment.startsWith("./") || segment.startsWith("../")
 }
 
 /** see {@link RelativePathResolverConfig.resolvePath} for details. */

--- a/src/packageman/base.ts
+++ b/src/packageman/base.ts
@@ -9,6 +9,23 @@ import { resolvePathFromImportMapEntries, type ResolvePathFromImportMapEntriesCo
 import type { ImportMapSortedEntries } from "../importmap/typedefs.ts"
 
 
+export interface RuntimePackageResolveImportConfig extends ResolvePathFromImportMapEntriesConfig {
+	/** a list of workspaces that should also be traversed in case the import resolution fails. */
+	workspaces: Array<RuntimePackage<any>>
+
+	/** once a workspace runtime-package has been visited, its path (returned by {@link RuntimePackage.getPath}) is saved to this `Set`,
+	 * so that it is not traversed again by any other deep child workspace during the current path-resolution task.
+	*/
+	visitedWorkspaces?: Set<string>
+}
+
+const defaultRuntimePackageResolveImportConfig: Omit<RuntimePackageResolveImportConfig, keyof ResolvePathFromImportMapEntriesConfig> = {
+	workspaces: [],
+	visitedWorkspaces: undefined,
+}
+
+const cachedRuntimePackage = new Map<string, RuntimePackage<any>>()
+
 /** an abstraction for import-map utilities of a general javascript runtime's package object with the schema `SCHEMA`.
  * - in the case of node, `SCHEMA` would represent `package.json`'s schema.
  * - in the case of deno, `SCHEMA` would represent `deno.json`, `deno.jsonc`, or `jsr.json`'s schema.
@@ -16,6 +33,21 @@ import type { ImportMapSortedEntries } from "../importmap/typedefs.ts"
  * @template SCHEMA a record type representing the package schema.
 */
 export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
+	/** specify all child workspaces of this package.
+	 * 
+	 * the child-workspaces will also inherit the import/export-resolution of this (parent) package,
+	 * and thereby, they will also implicitly inherit the import/export-resolution of their sibling packages,
+	 * nephew packages, children of nephew packages, and so on.
+	 * 
+	 * > [!important]
+	 * > the constructor of the subclasses do **not** typically parse the workspace paths from the provided schema,
+	 * > nor do they load the {@link RuntimePackage} associated with those workspaces,
+	 * > since it would require asynchronous operations (such as `fetch`) which cannot be performed inside the constructor.
+	 * > this is why you would either need to manually add/push your child-workspace {@link RuntimePackage} object,
+	 * > or use the asynchronous {@link fromUrl} static method in the subclasses to take care of auto-loading the children workspaces.
+	*/
+	public readonly childWorkspaces: Array<RuntimePackage<any>>
+
 	/** the path or url of the package json(c) file.
 	 * 
 	 * the {@link RuntimePackage | base class} does nothing with this information;
@@ -47,6 +79,7 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	constructor(package_object: SCHEMA, package_path: string) {
 		this.packageInfo = package_object
 		this.packagePath = package_path
+		this.childWorkspaces = []
 	}
 
 	/** get the package's name. */
@@ -69,7 +102,7 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	 * > [!tip]
 	 * > for test case examples and configuration options, see the documentation comments of {@link resolvePathFromImportMapEntries}
 	*/
-	resolveExport(path_alias: string, config?: Partial<ResolvePathFromImportMapEntriesConfig>): string | undefined {
+	resolveExport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
 		return resolvePathFromImportMapEntries(path_alias, this.exportMapSortedEntries, { sort: false, ...config })
 	}
 
@@ -81,11 +114,20 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	 * > [!tip]
 	 * > for test case examples and configuration options, see the documentation comments of {@link resolvePathFromImportMapEntries}
 	*/
-	resolveImport(path_alias: string, config?: Partial<ResolvePathFromImportMapEntriesConfig>): string | undefined {
+	resolveImport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
 		return resolvePathFromImportMapEntries(path_alias, this.importMapSortedEntries, { sort: false, ...config })
 	}
 
 	/** create an instance of this class by loading a package's json(c) file from a url or local file-system path.
+	 * 
+	 * > [!important]
+	 * > the resulting new instance is cached (memorized), so that it can be reused if another query with the same normalized path is provided.
+	 * > 
+	 * > _why are we forcing a cache mechanism on the base class?_
+	 * > 
+	 * > because {@link childWorkspaces} are referenced by their absolute path,
+	 * > and resolving an import through a child-workspace would involve the creation of that child workspace package via this method,
+	 * > thus leading to an exponential number of redundant re-creation of identical package manager objects.
 	 * 
 	 * > [!tip]
 	 * > the constructor uses a "JSONC" parser (from [@oazmi/kitchensink/stringman](https://jsr.io/@oazmi/kitchensink/0.9.10/src/stringman.ts)) for the fetched files.
@@ -96,7 +138,14 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 		INSTANCE = RuntimePackage<SCHEMA>,
 	>(this: ConstructorOf<INSTANCE, [SCHEMA, string]>, package_jsonc_path: URL | string): Promise<INSTANCE> {
 		package_jsonc_path = resolveAsUrl(package_jsonc_path, defaultResolvePath())
-		const package_object = json_parse(jsoncRemoveComments(await ((await fetch(package_jsonc_path, defaultFetchConfig)).text()))) as SCHEMA
-		return new this(package_object, package_jsonc_path.href)
+		const
+			package_jsonc_path_str = package_jsonc_path.href,
+			cached_result = cachedRuntimePackage.get(package_jsonc_path_str)
+		if (cached_result) { return cached_result as INSTANCE }
+		const
+			package_object = json_parse(jsoncRemoveComments(await ((await fetch(package_jsonc_path, defaultFetchConfig)).text()))) as SCHEMA,
+			new_instance = new this(package_object, package_jsonc_path_str)
+		cachedRuntimePackage.set(package_jsonc_path_str, new_instance as RuntimePackage<SCHEMA>)
+		return new_instance
 	}
 }

--- a/src/packageman/base.ts
+++ b/src/packageman/base.ts
@@ -4,24 +4,16 @@
  * @module
 */
 
-import { defaultFetchConfig, defaultResolvePath, json_parse, jsoncRemoveComments, resolveAsUrl, type ConstructorOf } from "../deps.ts"
+import { constructorOf, defaultFetchConfig, defaultResolvePath, isString, json_parse, jsoncRemoveComments, resolveAsUrl, type ConstructorOf } from "../deps.ts"
 import { resolvePathFromImportMapEntries, type ResolvePathFromImportMapEntriesConfig } from "../importmap/mod.ts"
 import type { ImportMapSortedEntries } from "../importmap/typedefs.ts"
 
 
 export interface RuntimePackageResolveImportConfig extends ResolvePathFromImportMapEntriesConfig {
-	/** a list of workspaces that should also be traversed in case the import resolution fails. */
-	workspaces: Array<RuntimePackage<any>>
-
 	/** once a workspace runtime-package has been visited, its path (returned by {@link RuntimePackage.getPath}) is saved to this `Set`,
-	 * so that it is not traversed again by any other deep child workspace during the current path-resolution task.
+	 * so that it is not traversed again by any other child/parent workspace during the current path-resolution task.
 	*/
-	visitedWorkspaces?: Set<string>
-}
-
-const defaultRuntimePackageResolveImportConfig: Omit<RuntimePackageResolveImportConfig, keyof ResolvePathFromImportMapEntriesConfig> = {
-	workspaces: [],
-	visitedWorkspaces: undefined,
+	workspacesVisited?: Set<string>
 }
 
 const cachedRuntimePackage = new Map<string, RuntimePackage<any>>()
@@ -33,21 +25,6 @@ const cachedRuntimePackage = new Map<string, RuntimePackage<any>>()
  * @template SCHEMA a record type representing the package schema.
 */
 export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
-	/** specify all child workspaces of this package.
-	 * 
-	 * the child-workspaces will also inherit the import/export-resolution of this (parent) package,
-	 * and thereby, they will also implicitly inherit the import/export-resolution of their sibling packages,
-	 * nephew packages, children of nephew packages, and so on.
-	 * 
-	 * > [!important]
-	 * > the constructor of the subclasses do **not** typically parse the workspace paths from the provided schema,
-	 * > nor do they load the {@link RuntimePackage} associated with those workspaces,
-	 * > since it would require asynchronous operations (such as `fetch`) which cannot be performed inside the constructor.
-	 * > this is why you would either need to manually add/push your child-workspace {@link RuntimePackage} object,
-	 * > or use the asynchronous {@link fromUrl} static method in the subclasses to take care of auto-loading the children workspaces.
-	*/
-	public readonly childWorkspaces: Array<RuntimePackage<any>>
-
 	/** the path or url of the package json(c) file.
 	 * 
 	 * the {@link RuntimePackage | base class} does nothing with this information;
@@ -79,7 +56,6 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	constructor(package_object: SCHEMA, package_path: string) {
 		this.packageInfo = package_object
 		this.packagePath = package_path
-		this.childWorkspaces = []
 	}
 
 	/** get the package's name. */
@@ -103,6 +79,8 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	 * > for test case examples and configuration options, see the documentation comments of {@link resolvePathFromImportMapEntries}
 	*/
 	resolveExport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
+		// if this workspace package has already been visited, do not traverse it further.
+		if (config?.workspacesVisited?.has(this.getPath())) { return }
 		return resolvePathFromImportMapEntries(path_alias, this.exportMapSortedEntries, { sort: false, ...config })
 	}
 
@@ -115,6 +93,8 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	 * > for test case examples and configuration options, see the documentation comments of {@link resolvePathFromImportMapEntries}
 	*/
 	resolveImport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
+		// if this workspace package has already been visited, do not traverse it further.
+		if (config?.workspacesVisited?.has(this.getPath())) { return }
 		return resolvePathFromImportMapEntries(path_alias, this.importMapSortedEntries, { sort: false, ...config })
 	}
 
@@ -125,8 +105,8 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 	 * > 
 	 * > _why are we forcing a cache mechanism on the base class?_
 	 * > 
-	 * > because {@link childWorkspaces} are referenced by their absolute path,
-	 * > and resolving an import through a child-workspace would involve the creation of that child workspace package via this method,
+	 * > because the workspace children/parents, in the {@link WorkspacePackage} subclass, are referenced by their absolute path,
+	 * > and resolving an import through a workspace package would involve the creation of that child/parent runtime package via this method,
 	 * > thus leading to an exponential number of redundant re-creation of identical package manager objects.
 	 * 
 	 * > [!tip]
@@ -147,5 +127,98 @@ export abstract class RuntimePackage<SCHEMA extends Record<string, any>> {
 			new_instance = new this(package_object, package_jsonc_path_str)
 		cachedRuntimePackage.set(package_jsonc_path_str, new_instance as RuntimePackage<SCHEMA>)
 		return new_instance
+	}
+}
+
+export abstract class WorkspacePackage<SCHEMA extends Record<string, any>> extends RuntimePackage<SCHEMA> {
+	/** specify all child workspaces of this package.
+	 * 
+	 * - the exports of every child-workspace package are inherited by _this_ runtime package.
+	 *   > example: if `packageB` is child-workspace of `packageA`, then `packageA.exports` would be a superset of `packageB.exports`.
+	 * - similarly, the imports of _this_ runtime package will be implicitly available for all child-workspace packages.
+	 *   > example: if `packageB` is child-workspace of `packageA`, then `packageA.imports` would be a subset of `packageB.imports`.
+	 *   
+	 *   > [!note]
+	 *   > since child-workspaces are also considered to be dependencies of the parent package (the monorepo),
+	 *   > each child-workspace would be available to for importation by all child-workspaces.
+	 *   > in other words, sibling packages of the workspace would be able to import one another.
+	 * 
+	 * > [!important]
+	 * > the constructor of the subclasses do **not** typically parse the workspace paths from the provided schema,
+	 * > nor do they load the {@link WorkspacePackage} associated with those workspaces,
+	 * > since it would require asynchronous operations (such as `fetch`) which cannot be performed inside the constructor.
+	 * > this is why you would either need to manually add/push your child/parent-workspace {@link WorkspacePackage} object,
+	 * > or use the asynchronous {@link fromUrl} static method in the subclasses to take care of auto-loading and auto-injecting parent and child workspaces.
+	*/
+	public readonly workspaceChildren: Array<WorkspacePackage<any>>
+
+	/** specify all parent workspaces of this package.
+	 * 
+	 * - the imports of _this_ runtime package will be implicitly available for all child-workspace packages.
+	 *   > example: if `packageB` is child-workspace of `packageA`, then `packageA.imports` would be a subset of `packageB.imports`.
+	 * - the exports of every child-workspace package are inherited by _this_ runtime package.
+	 *   > example: if `packageB` is child-workspace of `packageA`, then `packageA.exports` would be a superset of `packageB.exports`.
+	 * 
+	 * > [!important]
+	 * > the constructor of the subclasses do **not** typically parse the workspace paths from the provided schema,
+	 * > nor do they load the {@link WorkspacePackage} associated with those workspaces,
+	 * > since it would require asynchronous operations (such as `fetch`) which cannot be performed inside the constructor.
+	 * > this is why you would either need to manually add/push your child/parent-workspace {@link WorkspacePackage} object,
+	 * > or use the asynchronous {@link fromUrl} static method in the subclasses to take care of auto-loading and auto-injecting parent and child workspaces.
+	*/
+	public readonly workspaceParents: Array<WorkspacePackage<any>>
+
+	constructor(package_object: SCHEMA, package_path: string) {
+		super(package_object, package_path)
+		this.workspaceChildren = []
+		this.workspaceParents = []
+	}
+
+	/** add a child workspace package, either by providing its path (absolute or relative), or by providing its {@link WorkspacePackage} object.
+	 * 
+	 * the exports of the added child workspace will become available to this package during workspace export-resolution.
+	*/
+	async addWorkspaceChild(package_jsonc_path: URL | string): Promise<void>
+	async addWorkspaceChild(runtime_package: WorkspacePackage<any>): Promise<void>
+	async addWorkspaceChild(package_or_path: URL | string | WorkspacePackage<any>): Promise<void> {
+		const
+			this_constructor = constructorOf(this) as unknown as typeof WorkspacePackage<SCHEMA>,
+			this_package_path = this.getPath(),
+			package_is_path = isString(package_or_path) || package_or_path instanceof URL,
+			// convert any relative workspace paths to absolute url-paths, if they're not already.
+			package_url = package_is_path ? resolveAsUrl(package_or_path, this_package_path) : undefined,
+			child_package = package_is_path
+				// below, a type error is raised by `this_constructor`, due to the fact `WorkspacePackage` is an abstract class, hence it should not instantiate an object.
+				? await (this_constructor as any).fromUrl(package_url!) as WorkspacePackage<SCHEMA>
+				: package_or_path
+		// we should ideally check for pre-existence of the `child_package` within `this.workspaceChildren`,
+		// by comparing its `child_package.getPath()` with the existing children's paths.
+		// but during import/export-resolution, duplicate paths will not be traversed more than once anyway, so it doesn't really matter that much.
+		this.workspaceChildren.push(child_package)
+		child_package.workspaceParents.push(this)
+	}
+
+	/** add a parent (monorepo) to this package, either by providing its path (absolute or relative), or by providing its {@link WorkspacePackage} object.
+	 * 
+	 * the imports of the added parent workspace will become available to this package during workspace import-resolution.
+	*/
+	async addWorkspaceParent(package_jsonc_path: URL | string): Promise<void>
+	async addWorkspaceParent(runtime_package: WorkspacePackage<any>): Promise<void>
+	async addWorkspaceParent(package_or_path: URL | string | WorkspacePackage<any>): Promise<void> {
+		const
+			this_constructor = constructorOf(this) as unknown as typeof WorkspacePackage<SCHEMA>,
+			this_package_path = this.getPath(),
+			package_is_path = isString(package_or_path) || package_or_path instanceof URL,
+			// convert any relative workspace paths to absolute url-paths, if they're not already.
+			package_url = package_is_path ? resolveAsUrl(package_or_path, this_package_path) : undefined,
+			parent_package = package_is_path
+				// below, a type error is raised by `this_constructor`, due to the fact `WorkspacePackage` is an abstract class, hence it should not instantiate an object.
+				? await (this_constructor as any).fromUrl(package_url!) as WorkspacePackage<SCHEMA>
+				: package_or_path
+		// we should ideally check for pre-existence of the `parent_package` within `this.workspaceParents`,
+		// by comparing its `parent_package.getPath()` with the existing parent's paths.
+		// but during import/export-resolution, duplicate paths will not be traversed more than once anyway, so it doesn't really matter that much.
+		this.workspaceParents.push(parent_package)
+		parent_package.workspaceChildren.push(this)
 	}
 }

--- a/src/packageman/base.ts
+++ b/src/packageman/base.ts
@@ -176,7 +176,7 @@ export abstract class WorkspacePackage<SCHEMA extends Record<string, any>> exten
 
 	/** add a child workspace package, either by providing its path (absolute or relative), or by providing its {@link WorkspacePackage} object.
 	 * 
-	 * the exports of the added child workspace will become available to this package during workspace export-resolution.
+	 * the exports of the added child workspace will become available to this package during workspace export-resolution ({@link resolveWorkspaceExport}).
 	*/
 	async addWorkspaceChild(package_jsonc_path: URL | string): Promise<void>
 	async addWorkspaceChild(runtime_package: WorkspacePackage<any>): Promise<void>
@@ -200,7 +200,7 @@ export abstract class WorkspacePackage<SCHEMA extends Record<string, any>> exten
 
 	/** add a parent (monorepo) to this package, either by providing its path (absolute or relative), or by providing its {@link WorkspacePackage} object.
 	 * 
-	 * the imports of the added parent workspace will become available to this package during workspace import-resolution.
+	 * the imports of the added parent workspace will become available to this package during workspace import-resolution ({@link resolveWorkspaceImport}).
 	*/
 	async addWorkspaceParent(package_jsonc_path: URL | string): Promise<void>
 	async addWorkspaceParent(runtime_package: WorkspacePackage<any>): Promise<void>
@@ -220,5 +220,69 @@ export abstract class WorkspacePackage<SCHEMA extends Record<string, any>> exten
 		// but during import/export-resolution, duplicate paths will not be traversed more than once anyway, so it doesn't really matter that much.
 		this.workspaceParents.push(parent_package)
 		parent_package.workspaceChildren.push(this)
+	}
+
+	/** this method tries to resolve the provided export `path_alias` to an absolute resource path,
+	 * using this package's child workspaces (i.e. not including _this_ package's _own_ exports).
+	 * 
+	 * - if there are no child-workspaces, or if the child-workspaces fail to resolve the exported `path_alias`, then `undefined` will be returned.
+	 * - this method does not inspect this package's own exports. you should use {@link resolveExport} for that.
+	*/
+	resolveWorkspaceExport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
+		const
+			{ workspacesVisited = new Set<string>(), ...import_map_config } = config ?? {},
+			workspace_children = this.workspaceChildren,
+			current_workspaces_path = this.getPath()
+		// if this workspace has already been visited, do not traverse it further.
+		if (workspacesVisited.has(current_workspaces_path)) { return }
+		// we share the `workspacesVisited` object among the child-workspaces,
+		// so that any runtime-package path that has been considered at least once will not be tried twice in an alternate child-workspace.
+		// NOTE: this may be unnecessary given that parent to child traversal should not lead to a circular dependency loop,
+		// but it is still possible if the end user had explicitly made such a circular dependency (in which case the visited set would be needed).
+		workspacesVisited.add(current_workspaces_path)
+		for (const runtime_package of workspace_children) {
+			const resolved_path = runtime_package.resolveExport(path_alias, {
+				workspacesVisited,
+				...import_map_config,
+			}) ?? runtime_package.resolveWorkspaceExport(path_alias, {
+				workspacesVisited,
+				...import_map_config,
+			})
+			if (resolved_path) { return resolved_path }
+		}
+		return
+	}
+
+	/** this method tries to resolve the provided import `path_alias` done by some resource within this package,
+	 * using the internal {@link importMapSortedEntries} list of import-aliases that this package uses.
+	 * 
+	 * - if no import resources match the given `path_alias` within this package, then this package's {@link workspaceParents} will be traversed.
+	 * - if there are no parent-workspaces, or if the parent-workspaces fail to resolve this `path_alias`, then `undefined` will be returned.
+	 *   (which would probably imply that the given `path_alias` is already either an absolute or relative path, or perhaps incorrect altogether)
+	 * 
+	 * > [!tip]
+	 * > for test case examples and configuration options, see the documentation comments of {@link resolvePathFromImportMapEntries}
+	*/
+	resolveWorkspaceImport(path_alias: string, config?: Partial<RuntimePackageResolveImportConfig>): string | undefined {
+		const
+			{ workspacesVisited = new Set<string>(), ...import_map_config } = config ?? {},
+			workspace_parents = this.workspaceParents,
+			current_workspaces_path = this.getPath()
+		// if this workspace has already been visited, do not traverse it further.
+		if (workspacesVisited.has(current_workspaces_path)) { return }
+		// we share the `workspacesVisited` object among the parent-workspaces,
+		// so that any runtime-package path that has been considered at least once will not be tried twice in an alternate parent-workspace.
+		workspacesVisited.add(current_workspaces_path)
+		for (const runtime_package of workspace_parents) {
+			const resolved_path = runtime_package.resolveImport(path_alias, {
+				workspacesVisited,
+				...import_map_config,
+			}) ?? runtime_package.resolveWorkspaceImport(path_alias, {
+				workspacesVisited,
+				...import_map_config,
+			})
+			if (resolved_path) { return resolved_path }
+		}
+		return
 	}
 }

--- a/src/packageman/deno.ts
+++ b/src/packageman/deno.ts
@@ -285,7 +285,7 @@ export class DenoPackage extends WorkspacePackage<DenoJsonSchema> {
 		} else if (url_is_directory) {
 			// if the user had provided a directory path, then we'll have to scan for the list of well-known package files in that directory.
 			const
-				package_json_urls = deno_package_json_filenames.map((json_filename) => new URL(json_filename, package_path_url)),
+				package_json_urls = denoPackageJsonFilenames.map((json_filename) => new URL(json_filename, package_path_url)),
 				// we don't use the head method below, because "file://" urls do not support the head method.
 				valid_url = await fetchScanUrls(package_json_urls)
 			// when no "deno.json" or equivalent package manager json file is found in the provided directory, we'll have to throw an error.
@@ -325,18 +325,18 @@ interface JsrPackageMeta {
 	versions: Record<string, { yanked?: boolean }>
 }
 
-const
-	jsr_base_url = "https://jsr.io",
-	deno_package_json_filenames = [
-		"./deno.json",
-		"./deno.jsonc",
-		"./jsr.json",
-		"./jsr.jsonc",
-		// TODO: the use of "package.json" is not supported for now, since it will complicate the parsing of the import/export-maps (due to having a different structure).
-		//   in the future, I might write a `npmPackageToDenoJson` function to transform the imports (dependencies) and exports.
-		// "./package.json",
-		// "./package.jsonc", // as if such a thing will ever exist, lol
-	]
+const jsr_base_url = "https://jsr.io"
+
+export const denoPackageJsonFilenames = [
+	"./deno.json",
+	"./deno.jsonc",
+	"./jsr.json",
+	"./jsr.jsonc",
+	// TODO: the use of "package.json" is not supported for now, since it will complicate the parsing of the import/export-maps (due to having a different structure).
+	//   in the future, I might write a `npmPackageToDenoJson` function to transform the imports (dependencies) and exports.
+	// "./package.json",
+	// "./package.jsonc", // as if such a thing will ever exist, lol
+]
 
 /** given a jsr schema uri (such as `jsr:@std/assert/assert-equals`), this function resolves the http url of the package's metadata file (i.e. `deno.json(c)`).
  * 
@@ -386,7 +386,7 @@ export const jsrPackageToMetadataUrl = async (jsr_package: `jsr:${string}` | URL
 
 	const
 		base_host = new URL(`@${scope}/${pkg}/${resolved_semver}/`, jsr_base_url),
-		deno_json_urls = deno_package_json_filenames.map((json_filename) => new URL(json_filename, base_host))
+		deno_json_urls = denoPackageJsonFilenames.map((json_filename) => new URL(json_filename, base_host))
 
 	// trying to fetch various possible "deno.json(c)" files and their alternatives, sequentially, and returning the url of the first successful response.
 	const valid_url = await fetchScanUrls(deno_json_urls, { method: "HEAD" })

--- a/src/plugins/filters/entry.ts
+++ b/src/plugins/filters/entry.ts
@@ -132,7 +132,8 @@ export interface EntryPluginSetupConfig {
 	*/
 	enableInheritPluginData: boolean
 
-	/** enable scanning of parental/ancestral directories of your project's {@link initialPluginData | base directory},
+	/** enable scanning of parental/ancestral directories of your project's
+	 * {@link InitialPluginData.runtimePackage | base directory (`initialPluginData.runtimePackage`)},
 	 * so that all relevant workspace packages up the directory tree can be discovered and cached.
 	 * 
 	 * this would permit the resolution of workspace package aliases that are not directly mentioned in your "deno.json" package file.

--- a/src/plugins/filters/entry.ts
+++ b/src/plugins/filters/entry.ts
@@ -66,7 +66,7 @@
 */
 
 import { bind_map_get, bind_map_has, bind_map_set, DEBUG, getUriScheme, isString, joinPaths, pathToPosixPath } from "../../deps.ts"
-import { RuntimePackage } from "../../packageman/base.ts"
+import { RuntimePackage, type WorkspacePackage } from "../../packageman/base.ts"
 import { DenoPackage } from "../../packageman/deno.ts"
 import { logLogger } from "../funcdefs.ts"
 import type { nodeModulesResolverFactory, resolverPlugin } from "../resolvers.ts"
@@ -82,13 +82,13 @@ export interface InitialPluginData extends Omit<CommonPluginData, "runtimePackag
 	 * so that your project's import and export aliases can be resolved appropriately.
 	 * 
 	 * there are several ways for you to specify your runtime package for package-resolution support:
-	 * - provide an existing {@link RuntimePackage} object.
+	 * - provide an existing {@link WorkspacePackage} object.
 	 * - provide a path `string` or `URL` to the package json(c) file (such as "deno.json", "jsr.jsonc", "package.json", etc...).
 	 * - provide a directory-path `string` or `URL` (**must** end with a trailing slash `"/"`) where a package json(c) file exists,
 	 *   and the plugin will scan for the following files at that location in the provided order:
 	 *   - `"deno.json"`, `"deno.jsonc"`, `"jsr.json"`, `"jsr.jsonc"`, `"package.json"`, `"package.jsonc"`.
 	*/
-	runtimePackage?: RuntimePackage<any> | URL | string
+	runtimePackage?: WorkspacePackage<any> | URL | string
 }
 
 /** configuration options for the {@link entryPluginSetup} esbuild-setup factory function. */
@@ -350,7 +350,7 @@ export const entryPlugin = (config?: Partial<EntryPluginSetupConfig>): EsbuildPl
  * there are several ways to specify the current runtime package (a class instance, a file path/url, or a directory path/url).
  * for all available options, see the documentation comments of {@link InitialPluginData.runtimePackage}.
 */
-const resolveRuntimePackage = async (build: EsbuildPluginBuild, initialRuntimePackage: InitialPluginData["runtimePackage"]): Promise<RuntimePackage<any> | undefined> => {
+const resolveRuntimePackage = async (build: EsbuildPluginBuild, initialRuntimePackage: InitialPluginData["runtimePackage"]): Promise<WorkspacePackage<any> | undefined> => {
 	if (!initialRuntimePackage) { return }
 	if (initialRuntimePackage instanceof RuntimePackage) { return initialRuntimePackage }
 	let deno_json_path = initialRuntimePackage

--- a/src/plugins/filters/jsr.ts
+++ b/src/plugins/filters/jsr.ts
@@ -76,7 +76,10 @@ export const jsrPluginSetup = (config: Partial<JsrPluginSetupConfig> = {}): Esbu
 				runtimePackage = await DenoPackage.fromUrl(path),
 				relative_alias_pathname = parsePackageUrl(path).pathname,
 				relative_alias = relative_alias_pathname === "/" ? "." : ensureStartDotSlash(relative_alias_pathname),
-				path_url = runtimePackage.resolveExport(relative_alias, { baseAliasDir: "" })
+				import_config = { baseAliasDir: "" },
+				path_url = runtimePackage.resolveExport(relative_alias, import_config)
+			// TODO: I believe workspace resolution (the commented line below) is not needed here, because the resolvers-plugin will take care of it. (but I could be wrong)
+			// ?? runtimePackage.resolveWorkspaceExport(relative_alias, import_config)?.[0]
 			// TODO: maybe instead of throwing a js error, we should return a result to esbuild with the message embedded in `result.errors[0]`.
 			if (!path_url) { throw new Error(`failed to resolve the path "${path}" from the deno package: "jsr:${runtimePackage.getName()}@${runtimePackage.getVersion()}"`) }
 			// the `build.resolve` call made below implicitly gets resolved by our http plugin, and eventually gets loaded by it too.

--- a/src/plugins/mod.ts
+++ b/src/plugins/mod.ts
@@ -16,7 +16,7 @@ export { DIRECTORY } from "./typedefs.ts"
 
 /** the configuration interface for the deno esbuild plugins suite {@link denoPlugins}. */
 export interface DenoPluginsConfig extends
-	Pick<EntryPluginSetupConfig, "initialPluginData">,
+	Pick<EntryPluginSetupConfig, "initialPluginData" | "scanAncestralWorkspaces">,
 	Pick<ResolverPluginSetupConfig, "log">,
 	Pick<NpmPluginSetupConfig, "autoInstall" | "peerDependencies" | "nodeModulesDirs">,
 	Pick<ImportMapResolverConfig, "globalImportMap"> {
@@ -55,6 +55,7 @@ export interface DenoPluginsConfig extends
 
 const defaultDenoPluginsConfig: DenoPluginsConfig = {
 	initialPluginData: undefined,
+	scanAncestralWorkspaces: false,
 	log: false,
 	logFor: ["npm", "resolver"],
 	autoInstall: true,
@@ -84,11 +85,11 @@ export const denoPlugins = (config?: Partial<DenoPluginsConfig>): [
 	resolver_pipeline_plugin: EsbuildPlugin,
 ] => {
 	const
-		{ acceptNamespaces, autoInstall, getCwd, globalImportMap, log, logFor, peerDependencies, nodeModulesDirs, initialPluginData } = { ...defaultDenoPluginsConfig, ...config },
+		{ acceptNamespaces, autoInstall, getCwd, globalImportMap, log, logFor, peerDependencies, nodeModulesDirs, initialPluginData, scanAncestralWorkspaces } = { ...defaultDenoPluginsConfig, ...config },
 		resolvePath = resolveResourcePathFactory(getCwd, isAbsolutePath)
 
 	return [
-		entryPlugin({ initialPluginData, acceptNamespaces }),
+		entryPlugin({ initialPluginData, scanAncestralWorkspaces, acceptNamespaces }),
 		httpPlugin({ acceptNamespaces, log: logFor.includes("http") ? log : false }),
 		jsrPlugin({ acceptNamespaces }),
 		npmPlugin({ acceptNamespaces, autoInstall, peerDependencies, nodeModulesDirs, log: logFor.includes("npm") ? log : false }),

--- a/src/plugins/typedefs.ts
+++ b/src/plugins/typedefs.ts
@@ -1,6 +1,6 @@
 import type { defaultGetCwd, esbuild, MaybePromise } from "../deps.ts"
 import type { ImportMap } from "../importmap/typedefs.ts"
-import type { RuntimePackage } from "../packageman/base.ts"
+import type { WorkspacePackage } from "../packageman/base.ts"
 import type { entryPlugin } from "./filters/entry.ts"
 import type { NpmAutoInstallCliConfig, npmPluginSetup, NpmPluginSetupConfig } from "./filters/npm.ts"
 import type { resolverPlugin } from "./resolvers.ts"
@@ -52,7 +52,7 @@ export interface CommonPluginData {
 	/** specifies the current scope's runtime package manager (such as deno, jsr, npm, node, etc...),
 	 * so that the package's own import and export aliases can be resolved appropriately.
 	*/
-	runtimePackage?: RuntimePackage<any>
+	runtimePackage?: WorkspacePackage<any>
 
 	/** you may control which resolvers to disable through the use of this property. */
 	resolverConfig?: {

--- a/test/1/mod.test.ts
+++ b/test/1/mod.test.ts
@@ -65,7 +65,7 @@ Deno.test("test http plugin", async () => {
 			//
 			// ...denoPlugins({
 			// 	globalImportMap: { "2d-array-utils": "https://jsr.io/@oazmi/kitchensink/0.9.2/src/array2d.ts" },
-			// 	pluginData: {
+			// 	initialPluginData: {
 			// 		runtimePackage: "./deno_json_dir/deno.jsonc",
 			// 		importMap: { "https://2d-lib": "https://jsr.io/@oazmi/kitchensink/0.9.2/src/array2d.ts" },
 			// 		resolverConfig: { useNodeModules: false },

--- a/test/2/a1/proj-a/deno.jsonc
+++ b/test/2/a1/proj-a/deno.jsonc
@@ -1,0 +1,11 @@
+{
+	"name": "projA",
+	"workspace": [
+		// a nested workspace. this is something that deno itself does not support,
+		// but our plugin will resolve it just fine.
+		"../../d1/proj-d"
+	],
+	"exports": {
+		".": "./mod.ts"
+	}
+}

--- a/test/2/a1/proj-a/mod.ts
+++ b/test/2/a1/proj-a/mod.ts
@@ -1,0 +1,8 @@
+import { exportD } from "projD"
+import { positiveRect } from "@external/1/struct"
+
+
+console.log("loaded: \"projA\"")
+export const exportA = "an export from \"projA\""
+exportD.toUpperCase()
+positiveRect({ x: -1, y: 1, width: 5, height: -5 })

--- a/test/2/b1/b2/proj-b/jsr.jsonc
+++ b/test/2/b1/b2/proj-b/jsr.jsonc
@@ -1,0 +1,7 @@
+{
+	"name": "projB",
+	"version": "0.1.2",
+	"exports": {
+		".": "./mod.ts"
+	}
+}

--- a/test/2/b1/b2/proj-b/mod.ts
+++ b/test/2/b1/b2/proj-b/mod.ts
@@ -1,0 +1,11 @@
+import { exportA } from "jsr:projA"
+import { exportC } from "projC"
+// import { exportD } from "jsr:projD@0.1.4" // deno would not permit this nephew import, but our plugin does.
+
+
+console.log("loaded: \"projB\"")
+export const exportB = "an export from \"projB\""
+exportA.toUpperCase()
+exportB.toUpperCase()
+exportC.toUpperCase()
+// exportD.toUpperCase()

--- a/test/2/b1/b2/proj-b/mod.ts
+++ b/test/2/b1/b2/proj-b/mod.ts
@@ -1,5 +1,5 @@
 import { exportA } from "jsr:projA"
-import { exportC } from "projC"
+import { exportC } from "projC/main"
 // import { exportD } from "jsr:projD@0.1.4" // deno would not permit this nephew import, but our plugin does.
 
 

--- a/test/2/c1/c2/c3/proj-c/deno.json
+++ b/test/2/c1/c2/c3/proj-c/deno.json
@@ -1,0 +1,10 @@
+{
+	"name": "projC",
+	"imports": {
+		"@external/3": "npm:@oazmi/tsignal@0.3.2"
+	},
+	"exports": {
+		".": "./mod.ts"
+	},
+	"nodeModulesDir": "none"
+}

--- a/test/2/c1/c2/c3/proj-c/deno.json
+++ b/test/2/c1/c2/c3/proj-c/deno.json
@@ -4,7 +4,8 @@
 		"@external/3": "npm:@oazmi/tsignal@0.3.2"
 	},
 	"exports": {
-		".": "./mod.ts"
+		".": "./mod.ts",
+		"./main": "./mod.ts"
 	},
 	"nodeModulesDir": "none"
 }

--- a/test/2/c1/c2/c3/proj-c/mod.ts
+++ b/test/2/c1/c2/c3/proj-c/mod.ts
@@ -1,0 +1,8 @@
+import { trimStartSlashes } from "@external/2"
+import { Context } from "@external/3"
+
+
+console.log("loaded: \"projC\"")
+export const exportC = "an export from \"projC\""
+new Context()
+trimStartSlashes("//a-//a-//a-///ava ch-ch-ch-cchicken. steve's lava chicken is tasty as hell.")

--- a/test/2/d1/proj-d/jsr.json
+++ b/test/2/d1/proj-d/jsr.json
@@ -1,0 +1,7 @@
+{
+	"name": "projD",
+	"version": "0.1.4",
+	"exports": {
+		".": "./mod.ts"
+	}
+}

--- a/test/2/d1/proj-d/mod.ts
+++ b/test/2/d1/proj-d/mod.ts
@@ -1,0 +1,7 @@
+import { throttle } from "@external/1/lambda"
+
+
+console.log("loaded: \"projD\"")
+export const exportD = "an export from \"projD\""
+const a = throttle(500, () => { })
+a()

--- a/test/2/deno.json
+++ b/test/2/deno.json
@@ -1,0 +1,12 @@
+{
+	"workspace": [
+		"a1/proj-a",
+		"b1/b2/proj-b/",
+		"./c1/c2/c3/proj-c/"
+	],
+	"imports": {
+		"@external/1": "jsr:@oazmi/kitchensink@0.9.14",
+		"@external/2": "https://jsr.io/@oazmi/kitchensink/0.9.14/src/pathman.ts"
+	},
+	"nodeModulesDir": "none"
+}

--- a/test/2/mod.test.ts
+++ b/test/2/mod.test.ts
@@ -1,0 +1,54 @@
+import { promiseTimeout } from "@oazmi/kitchensink/lambda"
+import esbuild from "npm:esbuild@0.25.0"
+import { denoPlugins } from "../../src/plugins/mod.ts"
+
+
+Deno.test("test workspace feature", async () => {
+	// alternate aliases for "projB" are "jsr:projB" and "jsr:projB@0.1.2".
+	// however, currently "./b1/b2/proj-b/" will not work,
+	// since there is no ancestor-directory workplace scanning feature implemented yet.
+	const
+		projb_workspace_aliases = ["projB", "jsr:projB", "jsr:projB@0.1.2"],
+		esbuild_config = {
+			absWorkingDir: import.meta.dirname,
+			outdir: "./dist/",
+			format: "esm" as const,
+			splitting: true,
+			bundle: true,
+			minifySyntax: true,
+			treeShaking: true,
+			write: false as const,
+			metafile: true as const,
+		}
+
+	for (const entrypoint of projb_workspace_aliases) {
+		const result = await esbuild.build({
+			...esbuild_config,
+			entryPoints: [{ in: entrypoint, out: "proj-b" }],
+			plugins: denoPlugins({
+				initialPluginData: {
+					runtimePackage: "./deno.json",
+					resolverConfig: { useNodeModules: false },
+				},
+				log: true,
+			}),
+		})
+	}
+
+	// the following will fail, since our plugin cannot scan ancestral directories for workspace packages.
+	// const result = await esbuild.build({
+	// 	...esbuild_config,
+	// 	entryPoints: [{ in: "./b1/b2/proj-b/" , out: "proj-b" }],
+	// 	plugins: denoPlugins({
+	// 		initialPluginData: {
+	// 			runtimePackage: "./deno.json",
+	// 			resolverConfig: { useNodeModules: false },
+	// 		},
+	// 		log: true,
+	// 	}),
+	// })
+	// console.log(result.outputFiles.map((v) => (v.path)))
+
+	await esbuild.stop()
+	await promiseTimeout(500)
+})

--- a/test/2/mod1.test.ts
+++ b/test/2/mod1.test.ts
@@ -26,6 +26,7 @@ Deno.test("test workspace feature", async () => {
 			...esbuild_config,
 			entryPoints: [{ in: entrypoint, out: "proj-b" }],
 			plugins: denoPlugins({
+				scanAncestralWorkspaces: false,
 				initialPluginData: {
 					runtimePackage: "./deno.json",
 					resolverConfig: { useNodeModules: false },
@@ -33,21 +34,8 @@ Deno.test("test workspace feature", async () => {
 				log: true,
 			}),
 		})
+		// console.log(result.outputFiles.map((v) => (v.path)))
 	}
-
-	// the following will fail, since our plugin cannot scan ancestral directories for workspace packages.
-	// const result = await esbuild.build({
-	// 	...esbuild_config,
-	// 	entryPoints: [{ in: "./b1/b2/proj-b/" , out: "proj-b" }],
-	// 	plugins: denoPlugins({
-	// 		initialPluginData: {
-	// 			runtimePackage: "./deno.json",
-	// 			resolverConfig: { useNodeModules: false },
-	// 		},
-	// 		log: true,
-	// 	}),
-	// })
-	// console.log(result.outputFiles.map((v) => (v.path)))
 
 	await esbuild.stop()
 	await promiseTimeout(500)

--- a/test/2/mod2.test.ts
+++ b/test/2/mod2.test.ts
@@ -1,0 +1,45 @@
+import { promiseTimeout } from "@oazmi/kitchensink/lambda"
+import esbuild from "npm:esbuild@0.25.0"
+import { denoPlugins } from "../../src/plugins/mod.ts"
+
+
+Deno.test("test workspace scanning feature", async () => {
+	const
+		projb_workspace_aliases = ["projB", "jsr:projB", "jsr:projB@0.1.2"],
+		main_export_aliases = ["", ".", "./b1/b2/proj-b/mod.ts", ...projb_workspace_aliases],
+		esbuild_config = {
+			absWorkingDir: import.meta.dirname,
+			outdir: "./dist/",
+			format: "esm" as const,
+			splitting: true,
+			bundle: true,
+			minifySyntax: true,
+			treeShaking: true,
+			write: false as const,
+			metafile: true as const,
+		}
+
+	// the following direct bundling operations on `projB` ("./b1/b2/proj-b/jsr.jsonc")
+	// will require parent/ancestor directory scanning for the parental-workspace packages to get discovered.
+	// luckily, this kind of parental-workspace discovery/scanning can be conveniently done by the plugin;
+	// simply set this plugin's `scanAncestralWorkspaces` configuration option to `true`,
+	// and the plugin will traverse all ancestral directories of `initialPluginData.runtimePackage` (your project's "deno.json" or its directory).
+	for (const entrypoint of main_export_aliases) {
+		const result = await esbuild.build({
+			...esbuild_config,
+			entryPoints: [{ in: entrypoint, out: "proj-b" }],
+			plugins: denoPlugins({
+				scanAncestralWorkspaces: true,
+				initialPluginData: {
+					runtimePackage: "./b1/b2/proj-b/",
+					resolverConfig: { useNodeModules: false },
+				},
+				log: true,
+			}),
+		})
+		// console.log(result.outputFiles.map((v) => (v.path)))
+	}
+
+	await esbuild.stop()
+	await promiseTimeout(500)
+})

--- a/test/2/readme.md
+++ b/test/2/readme.md
@@ -1,0 +1,95 @@
+## test 2
+
+in this test, we validate the plugin's support for workspace package import and export resolution.
+
+workspace packages work in the following way:
+
+- ### rules:
+  - every package can import its own _exports_ (i.e. self-reference).
+  - every package has its child-package's _exports_ available to it as an export.
+  - every package has its parent-package's _imports_ available to it as an import.
+
+- ### implications:
+  the following rules can be implied from the three rules above:
+  - a package can import its from its sibling package's _exports_ (indirectly through the parent package).
+  - the root package's imports are available to all child, grandchild, and descendant packages.
+
+- ### example:
+  - assume that `W` is the root package, and that it consists of two child packages `X` and `Y`.
+  - and then assume that `Z` is a child package of `Y`.
+    ```mermaid
+    ---
+    config:
+      layout: elk
+    ---
+
+    flowchart TB
+    	W --> X & Y
+    	Y --> Z
+    ```
+  - this would result in the following relations:
+    - $W_{exports} = X_{exports} \cup Y_{exports} \equiv X_{exports} \cup Y_{exports} \cup Z_{exports}$
+    - $W_{imports} = W_{exports} \cup W_{external\_imports} \equiv X_{exports} \cup Y_{exports} \cup Z_{exports} \cup W_{external\_imports}$
+    - $X_{exports} = X_{own\_exports} \cup Z_{exports}$
+    - $X_{imports} = X_{external\_imports} \cup X_{exports} \cup W_{imports}$
+    - $Y_{exports} = Y_{own\_exports}$
+    - etc...
+
+## the test
+
+```mermaid
+---
+title: test project structure
+config:
+  layout: elk
+---
+
+flowchart TB
+	subgraph dir1["<code>_root/_</code><br>(root of workspace)"]
+		file1["<code>_./deno.json_</code>"]
+	end
+	file1 -- "workspace<br>member" --> dir2 & dir3 & dir4
+	file2 -- "workspace<br>member" --> dir5
+	linkStyle 0,1,2,3 stroke:#AA0000
+
+	hex1@{ shape: "hexagon", label: "<code>jsr:#1 as @external/1</code>" }
+	hex2@{ shape: "hexagon", label: "<code>http:#2 as @external/2</code>" }
+	hex3@{ shape: "hexagon", label: "<code>npm:#3 as @external/3</code>" }
+	hex4@{ shape: "hexagon", label: "<code>@external/1</code>" }
+	hex5@{ shape: "hexagon", label: "<code>@external/2</code>" }
+	hex6@{ shape: "hexagon", label: "<code>@external/1</code>" }
+	hex1 & hex2 -. "imports" .-> file1
+	hex3 -.-> file4
+	file1 -.-> hex5 -. "imports" .-> file4
+	file1 -.-> hex4 -. "imports" .-> file2
+	file2 -.-> hex6 -. "imports" .-> file5
+	linkStyle 4,5,6 stroke:#0000FF
+	linkStyle 7,8,9,10,11,12 stroke:#00AA00
+
+	subgraph group1[" "]
+		direction LR
+		style group1 fill:#00000000,stroke:none
+
+		subgraph dir2["<code>_root/a1/proj-a/_</code>"]
+			file2["<code>_./deno.jsonc_<br>name: **projA**</code>"]
+		end
+
+		subgraph dir3["<code>_root/b1/b2/proj-b/_</code><br>(the bundling target)"]
+			style dir3 fill:#FF9944
+			file3["<code>_./jsr.jsonc_<br>name: **projB**</code>"]
+		end
+
+		subgraph dir4["<code>_root/c1/c2/c3/proj-c/_</code>"]
+			file4["<code>_./deno.json_<br>name: **projC**</code>"]
+		end
+
+		subgraph dir5["<code>_root/d1/proj-d/_</code>"]
+			file5["<code>_./jsr.json_<br>name: **projD**</code>"]
+		end
+
+		file5 -. "imports from<br>**projD**" .-> file2
+		file2 -. "imports from<br>**projA**" .-> file3
+		file4 -. "imports from<br>**jsr:projC**" .-> file3
+		linkStyle 13,14,15 stroke:#00AA00
+	end
+```

--- a/todo.md
+++ b/todo.md
@@ -68,16 +68,20 @@
       (for instance, it may serve a deno-compatible ts file, but your bundle is intended to run in the browser).
       so, allowing the user to modify the http-header would let them overcome this issue.
 - [ ] add support for parsing `package.json` in the `DenoPackage` class for achieving full jsr-compatibility in the jsr-plugin.
-- [ ] add a function to detect the current runtime, so that it can be later used for predicting the base-project-level scope's `runtimePackage: RuntimePackage` (i.e. is it a `package.json(c)` or `deno.json(c)` or `jsr.json(c)`).
-  - consider creating a function `fetchScan: (urls: (URL | string)[]) => URL`,
-    which will sequentially try fetching the provided `urls` using the `"HEAD"` method, and follow any redirects,
-    then return the first (fully-followed) url that results in a valid http response.
-  - use the said function for validating the existence of multiple runtime-package json(c) files, sequentially,
-    and acquire the first one that exists to use as the url to the `runtimePackage`.
 - [ ] ~~in the entry-plugin, consider merging the initial-plugin-data resolver (`initialPluginDataInjector`) into the inherit-plugin-data resolver (`inheritPluginDataInjector`),
       if it provides significant speed boost.
       doing so might undo the 60% slowdown introduced in version `0.3.0` (where inherit-plugin-data was added).~~
   > the reduction in speed was a government propaganda, the cake was a lie, and carbon killed oxide (carbon "die" oxide, get it? haha humor +100, and everyone clapped while congratulating for eternity - [quack quack](https://www.youtube.com/watch?v=oyFQVZ2h0V8&t=11s))
+
+## (2025-04-20) pre-version `0.4.2` todo list
+
+- [x] add a function to detect the current runtime, so that it can be later used for predicting the base-project-level scope's `runtimePackage: RuntimePackage` (i.e. is it a `package.json(c)` or `deno.json(c)` or `jsr.json(c)`).
+- [x] create a function `fetchScan: (urls: (URL | string)[]) => URL`,
+      which will sequentially try fetching the provided `urls` ~~using the `"HEAD"` method~~ (`"HEAD"` is not supported by the file-uri scheme), and follow any redirects,
+      then return the first (fully-followed) url that results in a valid http response.
+  - use the said function for validating the existence of multiple runtime-package json(c) files, sequentially,
+    and acquire the first one that exists to use as the url to the `runtimePackage`.
+- (this version was never released, because forgorr, and now I has ragretts)
 
 ## (2025-04-19) pre-version `0.4.1` todo list
 

--- a/todo.md
+++ b/todo.md
@@ -73,9 +73,30 @@
       doing so might undo the 60% slowdown introduced in version `0.3.0` (where inherit-plugin-data was added).~~
   > the reduction in speed was a government propaganda, the cake was a lie, and carbon killed oxide (carbon "die" oxide, get it? haha humor +100, and everyone clapped while congratulating for eternity - [quack quack](https://www.youtube.com/watch?v=oyFQVZ2h0V8&t=11s))
 
+## pre-version `0.4.4` todo list
+
+- [ ] use esbuild type definitions from your own stud library in `jsr:@oazmi/esbuild-types` or `npm:@oazmi/esbuild-types`.
+- [ ] add a new logo and update the `./readme.md`.
+- [ ] use an updated version of `jsr:@oazmi/build-tools` to generate javascript bundles of this project.
+
+## (2025-08-14) pre-version `0.4.3` todo list
+
+- [x] create a new subclass `WorkspacePackage` of `RuntimePackage`, that adds two additional methods `resolveWorkspaceImport` and `resolveWorkspaceExport`,
+      which will traverse child and parent packages within the workspace to look for a suitable package capable of resolving the given alias.
+- [x] make `DenoPackage` extend `WorkspacePackage` instead of directly extending `RuntimePackage`,
+      and make the `DenoPackage.fromUrl` static function traverse and cache child packages referenced in `deno.json`'s `workspace` field.
+- [x] add a new config option `scanAncestralWorkspaces` to the entry-plugin, which, when enabled,
+      allows the plugin to traverse the ancestral directories of the user's project folder (where the deno package json file lies),
+      to discover deno workspace packages that may be at an upper level.
+- [x] fix [issue#7](https://github.com/oazmi/esbuild-plugin-deno/issues/7):
+      add support for deno workspaces and workspace discovery/scanning.
+      however, wildcards in the `workspace` field of `deno.json` are not currently supported.
+
 ## (2025-04-20) pre-version `0.4.2` todo list
 
 - [x] add a function to detect the current runtime, so that it can be later used for predicting the base-project-level scope's `runtimePackage: RuntimePackage` (i.e. is it a `package.json(c)` or `deno.json(c)` or `jsr.json(c)`).
+- [x] make the `DenoPackage.fromUrl` static function scan for deno compatible package json files
+      (`package.json(c)` or `deno.json(c)` or `jsr.json(c)`) when a path/url of a directory is provided, instead of a file.
 - [x] create a function `fetchScan: (urls: (URL | string)[]) => URL`,
       which will sequentially try fetching the provided `urls` ~~using the `"HEAD"` method~~ (`"HEAD"` is not supported by the file-uri scheme), and follow any redirects,
       then return the first (fully-followed) url that results in a valid http response.


### PR DESCRIPTION
this pull request adds support for workspace packages to the path resolver plugin (`resolverPluginSetup`), and fixes issue #7 .

for bundling against an `initialPluginData.runtimePackage` that is a package _within_ a workspace, this plugin will need to scan upper-level directories to discover the root workspace's `deno.json` (or equivalent) file, and become aware of sibling packages within the workspace.
this ancestral workspace directory scanning feature is not enabled by default;
the end user will have to set the newly added `scanAncestralWorkspaces` configuration option to `true` when initializing the plugin for it to scan upper-level directories for workspace projects.

### details:

- create a subclass `WorkspacePackage` of `RuntimePackage`, that adds two additional methods `resolveWorkspaceImport` and `resolveWorkspaceExport`, which traverse the child and parent packages within the workspace to look for a suitable package capable of resolving the given alias.
- make `DenoPackage` extend `WorkspacePackage` instead of directly extending `RuntimePackage`, and make the `DenoPackage.fromUrl` static function traverse and cache child packages referenced in `deno.json`'s `workspace` field.
- add a new config option `scanAncestralWorkspaces` to the entry-plugin, which, when enabled, allows the plugin to traverse the ancestral directories of the user's project folder (where the deno package json file lies), to discover deno workspace packages that may be at an upper-level.
- fixed a potential double-caching/race-condition in `RuntimePackage.fromUrl`, when multiple instances of `RuntimePackage` can be created for a single memoization, during an inverted network delay (i.e. when the first request resolves last, while the last request resolves first).
- add bundling tests for the workspace feature in `/test/2/mod1.test.ts` and `/test/2/mod2.test.ts`.

### breaking changes:

- no breaking changes were made that would invalidate an end user's existing code.
